### PR TITLE
fix: adds better support for checking async stale cache

### DIFF
--- a/cache/record_cache.go
+++ b/cache/record_cache.go
@@ -121,7 +121,7 @@ func (r *RecordCache[K, V]) refreshCache() {
 		r.removeStale()
 	}
 	if r.asyncFetcher != nil &&
-		(r.lastUpdated.IsZero() || r.lastUpdated.Before(time.Now().Truncate(asyncCacheCheckFrequency).Add(-1*r.allTtl))) {
+		(r.lastUpdated.IsZero() || !r.lastUpdated.After(time.Now().Truncate(asyncCacheCheckFrequency).Add(-1*r.allTtl))) {
 		r.refreshAllRecords()
 		r.lastUpdated = time.Now().Truncate(asyncCacheCheckFrequency)
 	}

--- a/cache/record_cache_test.go
+++ b/cache/record_cache_test.go
@@ -176,7 +176,7 @@ func TestRecordCache_SetAsyncFetcher(t *testing.T) {
 		{
 			name: "error when records added to cache is Stale",
 			args: args{
-				ttl: -20 * time.Second,
+				ttl: -70 * time.Second,
 				k:   "active2",
 			},
 			want:    0,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ellogroup/ello-golang-cache
 
-go 1.21.3
+go 1.21.5
 
 require (
 	github.com/go-redis/redismock/v9 v9.2.0


### PR DESCRIPTION
Because the async cache is only checked every minute, there were gaps between stale and next update times.

SOFT-2860